### PR TITLE
Specifying utf-8 in the HTML head

### DIFF
--- a/pages/head.html
+++ b/pages/head.html
@@ -19,5 +19,6 @@
         color: #00aaff;
       }
     </style>
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8" >
   </head>
   <body>


### PR DESCRIPTION
Hello,

Great book! I was reading through the HTML version, and noticed that github doesn't seem to send much over in the response header when serving up the HTML. This made my browser incorrectly guess that the encoding was    ISO-8859-1, and broke the example discussing ellipsis characters in buffers.

I've added a Content-Type in the HTML head section that ends up giving the proper hint to the browser. Hope this works for you!

Thanks for spending time on this great, open-source book!

-jer
